### PR TITLE
Add support for anonymous functions

### DIFF
--- a/lib/pipe_capture.ex
+++ b/lib/pipe_capture.ex
@@ -41,6 +41,10 @@ defmodule PipeCapture do
   defp pipe(expr, {:&, _, _} = call_args, position) do
     Macro.pipe(expr, {{:., [], [call_args]}, [], []}, position)
   end
+  
+  defp pipe(expr, {:fn, _, _} = call_args, position) do
+    Macro.pipe(expr, {{:., [], [call_args]}, [], []}, position)
+  end
 
   defp pipe(expr, call, position), do: Macro.pipe(expr, call, position)
 end


### PR DESCRIPTION
The interaction between pipes, function captures, and anonymous functions drives me nuts. For a language that favours simplicity and expressiveness for so much of its design this seems like a real wart of the language.

 ```elixir
"Hello World" |> fn x -> IO.puts x end
```

Should now work